### PR TITLE
feat(gh-2): add bifurcated workflow run matcher support

### DIFF
--- a/release-dashboard/README.md
+++ b/release-dashboard/README.md
@@ -53,3 +53,34 @@ npm run dev
 4. Staleness is computed as `commits_behind / commit_ceiling` and displayed as a continuous color gradient from bright green (fresh) to pale brown (stale).
 5. Environment, sort, and layout preferences persist via URL query parameters and browser cookies.
 6. Search (Cmd/Ctrl+F) filters services by display name or repo; layout toggles compact (3 columns) vs comfortable (2 columns) on large screens; dark mode follows system preference.
+
+## Bifurcated workflows (one workflow, multiple environments)
+
+Some repositories use a single workflow file that deploys to different environments (e.g. by branch or input). The dashboard supports this by letting multiple environments point to the **same** `workflow_file` and using an optional **run matcher** to decide which runs count for which environment.
+
+- **Model:** Each environment still has a required workflow file responsible for deploys. Multiple environments may reference the same file; then `run_match_strategy` and `run_match_value` differentiate runs.
+- **Supported matchers:**
+  - **`branch`** — only successful runs whose head branch equals `run_match_value` (e.g. `main` for production, `develop` for staging).
+  - **`event`** — only runs triggered by the given event (e.g. `workflow_dispatch`, `push`).
+  - **`any`** or NULL — latest successful run for that workflow (default; current behavior).
+
+**Creating rows for a bifurcated repo:** Auto-discovery only creates one row per (service, environment) when a workflow filename matches an env keyword. For a single shared workflow (e.g. `deploy.yml`), add the extra (service, environment, workflow_file, matcher) rows manually:
+
+1. Get the service `id` and the environment `id`s from the `services` and `environments` tables (e.g. in Supabase SQL editor or dashboard).
+2. Insert or update `service_environments` with the same `workflow_file` for each environment and set `run_match_strategy` and `run_match_value` as needed.
+
+Example (one workflow, production from `main`, staging from `develop`):
+
+```sql
+-- After the service and environments exist, add staging for a repo that uses deploy.yml for both:
+INSERT INTO service_environments (service_id, environment_id, workflow_file, run_match_strategy, run_match_value)
+SELECT s.id, e.id, 'deploy.yml', 'branch', 'develop'
+FROM services s, environments e
+WHERE s.github_repo = 'org/repo-name' AND e.slug = 'staging'
+ON CONFLICT (service_id, environment_id) DO UPDATE SET
+  workflow_file = EXCLUDED.workflow_file,
+  run_match_strategy = EXCLUDED.run_match_strategy,
+  run_match_value = EXCLUDED.run_match_value;
+```
+
+An admin UI or API to edit `service_environments` (including matcher) may be added in a future release.

--- a/release-dashboard/README.md
+++ b/release-dashboard/README.md
@@ -60,7 +60,7 @@ Some repositories use a single workflow file that deploys to different environme
 
 - **Model:** Each environment still has a required workflow file responsible for deploys. Multiple environments may reference the same file; then `run_match_strategy` and `run_match_value` differentiate runs.
 - **Supported matchers:**
-  - **`branch`** — only successful runs whose head branch equals `run_match_value` (e.g. `main` for production, `develop` for staging).
+  - **`branch`** — only successful runs whose head branch equals `run_match_value` (e.g. `main` for production, `develop` for staging). If `run_match_value` ends with `*`, it is treated as a prefix: we fetch one page of runs and filter client-side by branch name (e.g. `release/*` matches `release/1.0`, `release/2.0`).
   - **`event`** — only runs triggered by the given event (e.g. `workflow_dispatch`, `push`).
   - **`any`** or NULL — latest successful run for that workflow (default; current behavior).
 

--- a/release-dashboard/src/app/api/deploy-status/route.ts
+++ b/release-dashboard/src/app/api/deploy-status/route.ts
@@ -31,6 +31,8 @@ export async function GET(request: NextRequest) {
       `
       id,
       workflow_file,
+      run_match_strategy,
+      run_match_value,
       environment:environments!inner(id, slug, commit_ceiling),
       service:services!inner(id, display_name, github_repo, default_branch, installation_id,
         installation:github_installations!inner(installation_id)
@@ -61,6 +63,8 @@ export async function GET(request: NextRequest) {
     installation_id: svc.installation_id as string,
     service_environment_id: row.id as string,
     workflow_file: row.workflow_file as string,
+    run_match_strategy: (row.run_match_strategy as string | null) ?? null,
+    run_match_value: (row.run_match_value as string | null) ?? null,
   };
 
   const installationId = inst.installation_id as number;

--- a/release-dashboard/src/app/api/deployments/route.ts
+++ b/release-dashboard/src/app/api/deployments/route.ts
@@ -6,6 +6,8 @@ import type { DeploymentInfo, ServiceWithEnvironment } from "@/lib/types";
 type ServiceRow = {
   id: string;
   workflow_file: string;
+  run_match_strategy: string | null;
+  run_match_value: string | null;
   service: {
     id: string;
     display_name: string;
@@ -50,6 +52,8 @@ export async function GET(request: NextRequest) {
       `
       id,
       workflow_file,
+      run_match_strategy,
+      run_match_value,
       service:services!inner(
         id, display_name, github_repo, default_branch, installation_id,
         installation:github_installations!inner(installation_id)
@@ -78,6 +82,8 @@ export async function GET(request: NextRequest) {
       installation_id: row.service.installation_id,
       service_environment_id: row.id,
       workflow_file: row.workflow_file,
+      run_match_strategy: row.run_match_strategy ?? null,
+      run_match_value: row.run_match_value ?? null,
     };
   });
 

--- a/release-dashboard/src/app/page.tsx
+++ b/release-dashboard/src/app/page.tsx
@@ -25,6 +25,8 @@ async function getEnvironments(
 type ServiceRow = {
   id: string;
   workflow_file: string;
+  run_match_strategy: string | null;
+  run_match_value: string | null;
   service: {
     id: string;
     display_name: string;
@@ -47,6 +49,8 @@ async function getServicesForEnvironment(
       `
       id,
       workflow_file,
+      run_match_strategy,
+      run_match_value,
       service:services!inner(
         id, display_name, github_repo, default_branch, installation_id,
         installation:github_installations!inner(installation_id)
@@ -75,6 +79,8 @@ async function getServicesForEnvironment(
       installation_id: row.service.installation_id,
       service_environment_id: row.id,
       workflow_file: row.workflow_file,
+      run_match_strategy: row.run_match_strategy ?? null,
+      run_match_value: row.run_match_value ?? null,
     };
   });
 

--- a/release-dashboard/src/lib/github.ts
+++ b/release-dashboard/src/lib/github.ts
@@ -108,16 +108,33 @@ export async function fetchDeploymentInfo(
   };
 
   try {
-    const { data: runs } = await octokit.rest.actions.listWorkflowRuns({
+    const strategy = service.run_match_strategy ?? "any";
+    const value = service.run_match_value?.trim();
+
+    const listParams: Parameters<Octokit["rest"]["actions"]["listWorkflowRuns"]>[0] = {
       owner,
       repo,
       workflow_id: service.workflow_file,
       status: "success",
       per_page: 1,
-    });
+    };
+    if (strategy === "branch" && value) {
+      listParams.branch = value;
+    } else if (strategy === "event" && value) {
+      listParams.event = value;
+    }
+
+    const { data: runs } = await octokit.rest.actions.listWorkflowRuns(listParams);
 
     if (runs.workflow_runs.length === 0) {
-      return { ...baseResult, error: "No successful workflow runs found" };
+      const matcherHint =
+        strategy !== "any" && value
+          ? ` (matching ${strategy}=${value})`
+          : "";
+      return {
+        ...baseResult,
+        error: `No successful workflow runs found${matcherHint}`,
+      };
     }
 
     const latestRun = runs.workflow_runs[0];

--- a/release-dashboard/src/lib/github.ts
+++ b/release-dashboard/src/lib/github.ts
@@ -108,8 +108,8 @@ export async function fetchDeploymentInfo(
   };
 
   try {
-    const strategy = service.run_match_strategy ?? "any";
-    const value = service.run_match_value?.trim();
+    const matchStrategy = service.run_match_strategy ?? "any";
+    const matchValue = service.run_match_value?.trim();
 
     const listParams: Parameters<Octokit["rest"]["actions"]["listWorkflowRuns"]>[0] = {
       owner,
@@ -118,18 +118,25 @@ export async function fetchDeploymentInfo(
       status: "success",
       per_page: 1,
     };
-    if (strategy === "branch" && value) {
-      listParams.branch = value;
-    } else if (strategy === "event" && value) {
-      listParams.event = value;
+    if (matchValue) {
+      switch (matchStrategy) {
+        case "branch": {
+          listParams.branch = matchValue;
+          break;
+        }
+        case "event": {
+          listParams.event = matchValue;
+          break;
+        }
+      }
     }
 
     const { data: runs } = await octokit.rest.actions.listWorkflowRuns(listParams);
 
     if (runs.workflow_runs.length === 0) {
       const matcherHint =
-        strategy !== "any" && value
-          ? ` (matching ${strategy}=${value})`
+        matchStrategy !== "any" && matchValue
+          ? ` (matching ${matchStrategy}=${matchValue})`
           : "";
       return {
         ...baseResult,

--- a/release-dashboard/src/lib/github.ts
+++ b/release-dashboard/src/lib/github.ts
@@ -110,15 +110,19 @@ export async function fetchDeploymentInfo(
   try {
     const matchStrategy = service.run_match_strategy ?? "any";
     const matchValue = service.run_match_value?.trim();
+    const branchPrefix =
+      matchStrategy === "branch" && matchValue?.endsWith("*")
+        ? matchValue.slice(0, -1)
+        : null;
 
     const listParams: Parameters<Octokit["rest"]["actions"]["listWorkflowRuns"]>[0] = {
       owner,
       repo,
       workflow_id: service.workflow_file,
       status: "success",
-      per_page: 1,
+      per_page: branchPrefix !== null ? 100 : 1,
     };
-    if (matchValue) {
+    if (matchValue && branchPrefix === null) {
       switch (matchStrategy) {
         case "branch": {
           listParams.branch = matchValue;
@@ -133,7 +137,13 @@ export async function fetchDeploymentInfo(
 
     const { data: runs } = await octokit.rest.actions.listWorkflowRuns(listParams);
 
-    if (runs.workflow_runs.length === 0) {
+    const candidates = runs.workflow_runs;
+    const latestRun =
+      branchPrefix !== null
+        ? candidates.find((run) => run.head_branch?.startsWith(branchPrefix))
+        : candidates[0];
+
+    if (!latestRun) {
       const matcherHint =
         matchStrategy !== "any" && matchValue
           ? ` (matching ${matchStrategy}=${matchValue})`
@@ -143,8 +153,6 @@ export async function fetchDeploymentInfo(
         error: `No successful workflow runs found${matcherHint}`,
       };
     }
-
-    const latestRun = runs.workflow_runs[0];
     const deployedSha = latestRun.head_sha;
 
     const { data: commitData } = await octokit.rest.repos.getCommit({

--- a/release-dashboard/src/lib/types.ts
+++ b/release-dashboard/src/lib/types.ts
@@ -26,11 +26,15 @@ export type ServiceEnvironment = {
   service_id: string;
   environment_id: string;
   workflow_file: string;
+  run_match_strategy: string | null;
+  run_match_value: string | null;
 };
 
 export type ServiceWithEnvironment = Service & {
   service_environment_id: string;
   workflow_file: string;
+  run_match_strategy: string | null;
+  run_match_value: string | null;
 };
 
 export type SortOption = "deployed" | "alpha" | "staleness";

--- a/release-dashboard/supabase/migrations/20260305000000_add_environment_run_matcher.sql
+++ b/release-dashboard/supabase/migrations/20260305000000_add_environment_run_matcher.sql
@@ -1,0 +1,27 @@
+-- Optional run matcher for service_environments: when multiple environments
+-- point to the same workflow file, strategy + value differentiate which runs
+-- count for which environment (e.g. branch 'main' -> production, 'develop' -> staging).
+-- workflow_file remains required; matcher is an extension only.
+
+ALTER TABLE service_environments
+  ADD COLUMN run_match_strategy TEXT,
+  ADD COLUMN run_match_value TEXT;
+
+-- Strategy: 'any' or NULL = latest successful run (current behavior);
+-- 'branch' = filter by head branch; 'event' = filter by trigger event.
+-- Restrict strategy to known values.
+ALTER TABLE service_environments
+  ADD CONSTRAINT service_environments_run_match_strategy_check
+  CHECK (run_match_strategy IS NULL OR run_match_strategy IN ('any', 'branch', 'event'));
+
+-- When strategy is branch or event, run_match_value must be non-empty.
+ALTER TABLE service_environments
+  ADD CONSTRAINT service_environments_run_match_value_required
+  CHECK (
+    run_match_strategy IS NULL
+    OR run_match_strategy = 'any'
+    OR (run_match_value IS NOT NULL AND trim(run_match_value) <> '')
+  );
+
+COMMENT ON COLUMN service_environments.run_match_strategy IS 'Optional: any, branch, or event. When set with run_match_value, filters workflow runs for this environment.';
+COMMENT ON COLUMN service_environments.run_match_value IS 'Value for run_match_strategy (e.g. branch name or event name). Required when strategy is branch or event.';


### PR DESCRIPTION
## Summary

This PR implements support for **bifurcated workflows** (one workflow file deploying to multiple environments) and contributes to **GitHub issue #2** ([Add support or guidance for bifurcated GH workflows](https://github.com/Prudentia-Sciences/shipyard/issues/2)).

When multiple environments point to the same `workflow_file`, an optional run matcher (`run_match_strategy` + `run_match_value`) differentiates which workflow runs count for which environment (e.g. `branch`: `main` for production, `develop` for staging; or `event`: `workflow_dispatch` vs `push`).

## Changes

- **Schema:** New migration adds nullable `run_match_strategy` and `run_match_value` to `service_environments` with CHECK constraints.
- **Types & data flow:** `ServiceEnvironment` and `ServiceWithEnvironment` include optional matcher fields; all SELECTs and mappings updated.
- **Fetch logic:** `fetchDeploymentInfo` passes `branch` or `event` to `listWorkflowRuns` when matcher is set; otherwise unchanged (latest successful run).
- **Docs:** README section on bifurcated workflows, supported matchers, and SQL example for creating rows.

## Test Plan

1. Run migrations: `supabase db push` in `release-dashboard`.
2. Existing dashboards: no matcher set (NULL) → behavior unchanged.
3. For a repo with one workflow and branch-based deploys: add two `service_environments` rows (same `workflow_file`, different envs) with `run_match_strategy='branch'` and appropriate `run_match_value`; confirm dashboard shows correct latest deploy per environment.
4. Optional: set `run_match_strategy='event'` and `run_match_value='workflow_dispatch'` and confirm only matching runs are used.